### PR TITLE
[FR #25]: serve MCP over Streamable HTTP natively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to Proximo. Format loosely follows Keep a Changelog; version
 
 ## [Unreleased]
 
+### Added
+- **MCP over Streamable HTTP, natively** (upstream FR #25) — a new optional `proximo-mcp-http`
+  face (`pip install 'proximo-proxmox[mcp-http]'`) serves the SAME FastMCP instance the stdio
+  server runs over the MCP SDK's native Streamable HTTP transport, so networked MCP clients
+  (Claude Desktop/Code on another machine, web clients) no longer need a third-party stdio→HTTP
+  bridge that sits outside Proximo's perimeter. No adapter layer at all — it IS MCP, so the tool
+  registry, trust spine (PLAN/PROVE/UNDO, the gates), `PROXIMO_SURFACES` scoping, and the Proxmox
+  token scope are inherited by construction. Behind the shared `proximo.webguard` perimeter,
+  identical to the A2A/HTTP faces: fail-closed public bind (`PROXIMO_MCP_HTTP_TOKEN_FILE`,
+  refused without it on a non-localhost `PROXIMO_MCP_HTTP_HOST`), constant-time bearer on `/mcp`,
+  Host/DNS-rebind allowlist (`PROXIMO_MCP_HTTP_ALLOWED_HOSTS`), and the cross-origin (CSRF)
+  guard. Default `127.0.0.1:41243`; opt-in stateless / plain-JSON modes for load-balanced
+  deployments (`PROXIMO_MCP_HTTP_STATELESS` / `PROXIMO_MCP_HTTP_JSON`). The SDK's own DNS-rebind
+  layer is deliberately disabled in favor of the one authoritative webguard perimeter (two
+  driftable allowlists is how holes happen); proven end-to-end by the official MCP client in
+  `tests/test_mcphttp_e2e.py`.
+
 ## [0.24.0] — 2026-07-18
 
 **Ceph + SDN deep.** 603 → **715 tools**. The two planes hyperconverged operators asked for,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,10 @@ All notable changes to Proximo. Format loosely follows Keep a Changelog; version
   identical to the A2A/HTTP faces: fail-closed public bind (`PROXIMO_MCP_HTTP_TOKEN_FILE`,
   refused without it on a non-localhost `PROXIMO_MCP_HTTP_HOST`), constant-time bearer on `/mcp`,
   Host/DNS-rebind allowlist (`PROXIMO_MCP_HTTP_ALLOWED_HOSTS`), and the cross-origin (CSRF)
-  guard. Default `127.0.0.1:41243`; opt-in stateless / plain-JSON modes for load-balanced
-  deployments (`PROXIMO_MCP_HTTP_STATELESS` / `PROXIMO_MCP_HTTP_JSON`). The SDK's own DNS-rebind
+  guard. Default `127.0.0.1:41243`, serving **stateless** (`stateless_http=True` — the upstream
+  maintainer's call on the FR: multi-client behind a proxy is the deployment model, and nothing
+  in the governed surface needs a session; opt out with `PROXIMO_MCP_HTTP_STATELESS=0`); opt-in
+  plain-JSON responses with `PROXIMO_MCP_HTTP_JSON=1`. The SDK's own DNS-rebind
   layer is deliberately disabled in favor of the one authoritative webguard perimeter (two
   driftable allowlists is how holes happen); proven end-to-end by the official MCP client in
   `tests/test_mcphttp_e2e.py`.

--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ uvx proximo-proxmox            # zero-install run (PyPI package: proximo-proxmox
 # or: pip install proximo-proxmox            the MCP core
 # or: pip install "proximo-proxmox[a2a]"     + the optional A2A face
 # or: pip install "proximo-proxmox[http]"    + the optional HTTP/OpenAPI face
+# or: pip install "proximo-proxmox[mcp-http]" + the optional MCP-over-streamable-HTTP face
 # or, from source:  git clone https://github.com/john-broadway/proximo.git && cd proximo && uv pip install -e .
 ```
 
@@ -231,7 +232,7 @@ Wire it into your MCP client as the command `proximo`, with the `PROXIMO_*` env 
 >
 > **Big surface, scoped context:** you don't have to load the whole estate. `PROXIMO_SURFACES=pve,exec` registers only those planes (that pair = 202 tools) — unpicked planes never touch your context window; `audit_verify` always stays; a typo'd surface refuses startup.
 
-**The network faces (experimental, opt-in):** `proximo-a2a` speaks Agent2Agent; `proximo-http` serves plain HTTP + generated `/openapi.json` for no-code clients. Both serve the full surface through the **same governed dispatch** as MCP — no second code path, trust spine and token scope inherited. Fail-closed perimeter: loopback, bearer-token required off-localhost, DNS-rebind and CSRF defended. Details: [SECURITY.md](SECURITY.md).
+**The network faces (experimental, opt-in):** `proximo-a2a` speaks Agent2Agent; `proximo-http` serves plain HTTP + generated `/openapi.json` for no-code clients; `proximo-mcp-http` serves **MCP itself over Streamable HTTP** (the SDK's native transport) for networked MCP clients — no third-party stdio→HTTP bridge, so the perimeter stays Proximo's. All serve the full surface through the **same spine** as MCP — no second code path, trust spine and token scope inherited. Fail-closed perimeter: loopback, bearer-token required off-localhost, DNS-rebind and CSRF defended. Details: [SECURITY.md](SECURITY.md).
 
 ## At scale
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -237,17 +237,19 @@ access is broadest:
 - **The in-container exec edge.** `PROXIMO_ENABLE_EXEC=1` enables `ssh → pct exec`,
   which is near-root on the host. It's opt-in and fail-closed behind a CTID allowlist —
   any allowlist bypass, or a way to reach exec without the flag, is high severity.
-- **The network faces (A2A and HTTP).** The two optional network servers — `proximo-a2a`
-  (Agent2Agent) and `proximo-http` (HTTP/OpenAPI) — share one fail-closed perimeter
-  (`proximo.webguard`): both refuse non-localhost binds without a bearer token, and both
-  enforce a Host/DNS-rebind allowlist (`PROXIMO_A2A_ALLOWED_HOSTS` / `PROXIMO_HTTP_ALLOWED_HOSTS`).
-  Both serve the FULL governed tool surface through the SAME shared dispatch
-  (`proximo.governed.call_governed`) — the same `mcp.call_tool` spine path an MCP client takes,
-  so PLAN-by-default, PROVE, UNDO, the gates, and the Proxmox token scope apply identically, and
-  there is no second mutate path. The surface is scoped only by `PROXIMO_SURFACES` + the token
-  ACL, uniform for every transport. Auth bypass, header smuggling, rebind escape, a path that
-  invokes a tool bypassing `call_governed`, or a mutation that fires without the tool's own
-  confirm gate are all in scope.
+- **The network faces (A2A, HTTP, and MCP-over-streamable-HTTP).** The three optional network
+  servers — `proximo-a2a` (Agent2Agent), `proximo-http` (HTTP/OpenAPI), and `proximo-mcp-http`
+  (the MCP Streamable HTTP transport) — share one fail-closed perimeter (`proximo.webguard`):
+  all refuse non-localhost binds without a bearer token, and all enforce a Host/DNS-rebind
+  allowlist (`PROXIMO_A2A_ALLOWED_HOSTS` / `PROXIMO_HTTP_ALLOWED_HOSTS` /
+  `PROXIMO_MCP_HTTP_ALLOWED_HOSTS`). All serve the FULL governed tool surface through the SAME
+  spine path an MCP client takes — A2A and HTTP via the shared dispatch
+  (`proximo.governed.call_governed`, the same `mcp.call_tool` path), the MCP-HTTP face by
+  serving the FastMCP instance itself — so PLAN-by-default, PROVE, UNDO, the gates, and the
+  Proxmox token scope apply identically, and there is no second mutate path. The surface is
+  scoped only by `PROXIMO_SURFACES` + the token ACL, uniform for every transport. Auth bypass,
+  header smuggling, rebind escape, a path that invokes a tool bypassing the spine, or a mutation
+  that fires without the tool's own confirm gate are all in scope.
 - **Secret handling.** Proximo takes its PVE token by path/env, never as a literal in a
   shell line. A path where a token, key, or other secret is logged, echoed into the
   audit ledger, or otherwise persisted in cleartext is in scope. At load time, every

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -198,95 +198,58 @@ your client speaks:
 |---|---|---|---|
 | **REST / OpenAPI** — Open WebUI, dashboards, scripts, `curl` | `proximo-http` | `[http]` | No |
 | **A2A** — agent-to-agent callers | `proximo-a2a` | `[a2a]` | No |
-| **MCP** — Claude Desktop, Claude Code, Cursor | MCP is served over **stdio** only today | — | Yes — see below |
+| **MCP** — Claude Desktop, Claude Code, Cursor | `proximo-mcp-http` | `[mcp-http]` | No |
 
-Both network faces serve the **full governed surface** through the same spine (PLAN · PROVE · UNDO —
-and your token's ACL is still the floor). Both are opt-in, off unless you start them, and both carry
-the same fail-closed perimeter: a non-localhost bind refuses to start without a bearer token, the
-bearer is checked on every op, plus a Host/DNS-rebind allowlist and a CSRF guard.
+All three network faces serve the **full governed surface** through the same spine (PLAN · PROVE ·
+UNDO — and your token's ACL is still the floor). All are opt-in, off unless you start them, and all
+carry the same fail-closed perimeter: a non-localhost bind refuses to start without a bearer token,
+the bearer is checked on every op, plus a Host/DNS-rebind allowlist and a CSRF guard.
 
-### MCP over the network — a bridge, for now
+### MCP over the network — native
 
-The HTTP face speaks REST, not the MCP wire protocol, so an MCP client can't connect to it. Until a
-native MCP-over-HTTP transport lands ([#25](https://github.com/john-broadway/proximo/issues/25)), a
-remote MCP client needs a **stdio→HTTP bridge** in front of Proximo.
-
-> ⚠️ **The bridge becomes your perimeter.** It wraps Proximo's *stdio* path, so the fail-closed
-> perimeter above is **not** in the request path — whatever the bridge enforces is all there is. And
-> bridges differ: the Python `sparfenyuk/mcp-proxy` has **no inbound auth at all** (its
-> `API_ACCESS_TOKEN` is outbound-only, for when it acts as a client). Don't put an unauthenticated
-> bridge in front of a hypervisor.
->
-> Keep the token **read-only** (Step 2) until you've verified the perimeter yourself, and prefer
-> reaching it over a VPN to exposing it publicly.
-
-The recipe below uses [`punkpeye/mcp-proxy`](https://github.com/punkpeye/mcp-proxy) (npm), which
-enforces an `X-API-Key` on inbound requests, serves streamable HTTP at `/mcp`, and passes the
-container's environment to the Proximo child it spawns.
-
-**`Dockerfile`** — Proximo plus the bridge, one image:
-
-```dockerfile
-FROM ghcr.io/john-broadway/proximo:0.23.0
-RUN apt-get update && apt-get install -y --no-install-recommends nodejs npm \
- && npm install -g mcp-proxy@6.5.2 \
- && apt-get purge -y npm && apt-get autoremove -y && rm -rf /var/lib/apt/lists/*
-ENTRYPOINT ["mcp-proxy"]
-```
-
-**`proximo.env`** — as Step 3, but with the token path *inside* the container:
+`proximo-mcp-http` serves the MCP protocol itself over **Streamable HTTP** — the same FastMCP
+instance the stdio server runs, so there is no adapter layer and nothing to drift: it IS MCP, with
+the spine and your token's ACL inherited by construction. No third-party stdio→HTTP bridge, so the
+perimeter in the request path is **Proximo's own**, not a bridge's.
 
 ```bash
-PROXIMO_API_BASE_URL=https://YOUR-PVE-HOST:8006/api2/json
-PROXIMO_NODE=YOUR-NODE-NAME
-PROXIMO_TOKEN_PATH=/etc/proximo/pve-token
-PROXIMO_VERIFY_TLS=true
+pip install "proximo-proxmox[mcp-http]"
+
+# The bearer token the perimeter enforces — file mode 600, like every Proximo secret:
+openssl rand -hex 32 > mcp-bearer.token && chmod 600 mcp-bearer.token
+
+PROXIMO_MCP_HTTP_HOST=0.0.0.0 \
+PROXIMO_MCP_HTTP_TOKEN_FILE=./mcp-bearer.token \
+proximo-mcp-http
 ```
 
-**`docker-compose.yml`** — keep `pve-token` (mode `600`, from Step 2) beside it:
+Defaults and knobs (all `PROXIMO_MCP_HTTP_*`): binds loopback `127.0.0.1:41243` with no token
+required; **any non-localhost `_HOST` refuses to start without `_TOKEN_FILE`** — that's the same
+fail-closed rule as the other faces, not a warning. `_PORT` and `_ALLOWED_HOSTS` (comma-separated
+Host allowlist for the DNS-rebind guard — set it to your public hostname behind a reverse proxy)
+work like the sibling faces. Serving is **stateless by default** (multi-client behind a proxy is
+the deployment model; opt out with `_STATELESS=0` for session-stateful serving); `_JSON=1` answers
+POSTs with plain JSON instead of SSE for clients that prefer it. Put a reverse proxy in front for
+TLS, and prefer reaching it over a VPN to exposing it publicly; `GET /healthz` is open for health
+checks. Keep the Proxmox token **read-only** (Step 2) until you've verified the perimeter.
 
-```yaml
-services:
-  proximo:
-    build: .
-    container_name: proximo
-    env_file: proximo.env
-    environment:
-      # The BRIDGE's inbound key — generate with: openssl rand -hex 32
-      # Keep it here, not in proximo.env: that file is mounted into the container.
-      - MCP_PROXY_API_KEY=YOUR_KEY
-    volumes:
-      - .:/etc/proximo:ro
-    command: ["--host","0.0.0.0","--port","8096","--","proximo"]
-    expose:
-      - "8096"
-    # attach to your reverse proxy's network; don't publish the port to the host
-    networks: [proxy]
-networks:
-  proxy:
-    external: true
-```
-
-`--` separates the bridge's own flags from the command it spawns (`proximo`). Put a reverse proxy in
-front for TLS; the bridge answers an unauthenticated `GET /ping` for health checks.
-
-**Verify the perimeter before you wire any client** — a request with no key must be refused:
+**Verify the perimeter before you wire any client** — a request with no bearer must be refused:
 
 ```bash
-docker compose exec proximo sh -lc \
-  'node -e "fetch(\"http://127.0.0.1:8096/mcp\",{method:\"POST\"}).then(r=>console.log(r.status))"'
+curl -s -o /dev/null -w '%{http_code}\n' -X POST https://YOUR-HOST/mcp \
+  -H 'Content-Type: application/json'
 #   -> 401
 
-docker compose exec proximo sh -lc \
-  'node -e "fetch(\"http://127.0.0.1:8096/mcp\",{method:\"POST\",headers:{\"x-api-key\":\"YOUR_KEY\"}}).then(r=>console.log(r.status))"'
-#   -> 400/406, i.e. the key was accepted and the request reached the MCP layer
+curl -s -o /dev/null -w '%{http_code}\n' -X POST https://YOUR-HOST/mcp \
+  -H 'Content-Type: application/json' -H "Authorization: Bearer $(cat mcp-bearer.token)"
+#   -> 400/406, i.e. the bearer was accepted and the request reached the MCP layer
 ```
 
-**Claude Code** — connects natively, no shim:
+**Claude Code** — connects natively:
 
 ```bash
 claude mcp add --scope user --transport http proximo https://YOUR-HOST/mcp \
-  --header "X-API-Key: YOUR_KEY"
+  --header "Authorization: Bearer YOUR_TOKEN"
 ```
 
 `--scope user` matters: without it, `claude mcp add` defaults to *local* scope and the server is
@@ -303,7 +266,7 @@ closed (it rewrites that file from memory on exit, clobbering edits made while i
       "args": [
         "mcp-proxy",
         "--transport", "streamablehttp",
-        "--headers", "X-API-Key", "YOUR_KEY",
+        "--headers", "Authorization", "Bearer YOUR_TOKEN",
         "https://YOUR-HOST/mcp"
       ]
     }
@@ -338,7 +301,7 @@ The moment the token is gone, Proximo can do nothing at all.
 | **403 / a capability is in `cannot`** | The token lacks that privilege. Run `proximo doctor` — it prints the exact `pveum` command to grant it. For a `--privsep 1` token, effective permissions are the *intersection* of the user's ACL and the token's ACL: a freshly-created user has no ACL of its own, so the user-side grant is **always required**, not situational — `pveum acl modify <path> --users proximo@pve --roles <ROLE>`. |
 | **Connection refused / timeout** | Wrong host or port (the Proxmox API is `:8006`), or a firewall in the way. |
 | **`ct_exec` refused** | Exec is off by default (grants host root). It's opt-in via `PROXIMO_ENABLE_EXEC=1` + a CTID allowlist — only if you truly need it. |
-| **A remote MCP client can't connect** | MCP is served over stdio only (see **Remote / multi-client**); the HTTP face speaks REST, not MCP. A networked MCP client needs a bridge — and the bridge's own auth is then your only perimeter. |
+| **A remote MCP client can't connect** | The default `proximo` command serves stdio only — a networked MCP client needs `proximo-mcp-http` (see **Remote / multi-client**). The HTTP face speaks REST, not MCP. Check the bearer header and that `PROXIMO_MCP_HTTP_ALLOWED_HOSTS` includes the Host you're connecting through. |
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,12 @@ a2a = ["a2a-sdk[signing]>=1.1", "uvicorn>=0.30", "starlette>=1.3.1", "cryptograp
 # shared dispatch as A2A, served as plain REST for no-code clients (Open WebUI etc.). ASGI only; no a2a-sdk.
 # Install with: pip install 'proximo-proxmox[http]'
 http = ["uvicorn>=0.30", "starlette>=1.3.1"]
+# The MCP-over-streamable-HTTP face is OPTIONAL — the SAME FastMCP instance the stdio server runs,
+# served over the SDK's native Streamable HTTP transport behind the shared webguard perimeter (no
+# third-party stdio→HTTP bridge needed). mcp>=1.8.0 is the streamable_http_app() floor — the base
+# dep stays at its own floor; this extra only raises it for the face that needs the newer API.
+# Install with: pip install 'proximo-proxmox[mcp-http]'
+mcp-http = ["mcp>=1.8.0", "uvicorn>=0.30", "starlette>=1.3.1"]
 dev = [
   "pytest>=8", "pytest-asyncio>=1.4.0", "ruff>=0.6", "pyright>=1.1",
   "a2a-sdk[signing]>=1.1", "uvicorn>=0.30", "starlette>=1.3.1", "cryptography>=49.0.0",  # A2A slice + SIGNET tests
@@ -48,6 +54,7 @@ proximo = "proximo.server:main"            # the MCP server (stdio)
 proximo-proxmox = "proximo.server:main"    # alias matching the PyPI dist name (for `uvx proximo-proxmox`)
 proximo-a2a = "proximo._a2a_entry:main"     # A2A server shim (friendly error without [a2a] extra)
 proximo-http = "proximo._http_entry:main"   # HTTP/OpenAPI face shim (friendly error without [http] extra)
+proximo-mcp-http = "proximo._mcp_http_entry:main"  # MCP-over-streamable-HTTP face shim (friendly error without [mcp-http] extra)
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/proximo"]

--- a/src/proximo/_mcp_http_entry.py
+++ b/src/proximo/_mcp_http_entry.py
@@ -1,0 +1,46 @@
+"""Console-script shim for ``proximo-mcp-http``.
+
+The MCP-over-streamable-HTTP face is an optional extra, but the console script is registered in
+the base wheel. Importing ``proximo.mcphttp``'s server path without the extra raises
+ModuleNotFoundError inside the starlette/uvicorn import chain; this shim turns that into a
+one-line install hint instead of a traceback. (Same shape as ``_http_entry`` — the [mcp-http]
+extra is starlette + uvicorn + the SDK's streamable-HTTP floor, no a2a-sdk.)
+"""
+
+from __future__ import annotations
+
+import sys
+
+# Top-level modules the [mcp-http] extra provides — only their absence means "extra not
+# installed". Any other ModuleNotFoundError is a real bug and must traceback, not hide behind
+# the hint. (``mcp`` itself is a base dep, so it is never probed here; the extra only raises
+# its version floor for the streamable-HTTP API.)
+_EXTRA_MODULES = ("starlette", "uvicorn")
+
+
+def main() -> None:
+    # Source proximo.env before the app reads any config (same footgun + fail-dangerous shape as
+    # the stdio path — this face serves the same trust core, so a silently-inert
+    # PROXIMO_CONSENT_DIR would leave it ungated too). Real/inline env still wins.
+    from proximo.config import load_env_file
+    load_env_file()
+    try:
+        # main() imports uvicorn lazily at serve time and build_app imports starlette lazily —
+        # probe both HERE so a missing extra gets the hint below, not a traceback mid-startup.
+        import starlette  # noqa: F401
+        import uvicorn  # noqa: F401
+
+        from proximo.mcphttp import main as mcp_http_main
+    except ModuleNotFoundError as exc:
+        # Exact top-level match only: a missing SUBmodule (e.g. 'starlette._core') means the
+        # package is installed but broken — that must traceback so the real error is visible.
+        missing = exc.name or ""
+        if missing not in _EXTRA_MODULES:
+            raise
+        print(
+            f"proximo-mcp-http needs the optional MCP-HTTP dependencies ('{missing}' is not installed).\n"
+            'Install them with:  pip install "proximo-proxmox[mcp-http]"',
+            file=sys.stderr,
+        )
+        raise SystemExit(2) from None
+    mcp_http_main()

--- a/src/proximo/mcphttp.py
+++ b/src/proximo/mcphttp.py
@@ -31,11 +31,12 @@ _TOKEN_FILE_ENV = "PROXIMO_MCP_HTTP_TOKEN_FILE"  # noqa: S105 -- env var NAME, n
 _MCP_PATH = "/mcp"  # the SDK's default streamable-HTTP path, pinned explicitly (the guards match it)
 
 _TRUEISH = frozenset({"1", "true", "yes", "on"})
+_FALSISH = frozenset({"0", "false", "no", "off"})
 
 
 def build_app(url: str | None = None, *, token: str | None = None,
               allowed_hosts: list[str] | None = None,
-              stateless: bool = False, json_response: bool = False):
+              stateless: bool = True, json_response: bool = False):
     """Build the Proximo MCP-over-streamable-HTTP ASGI application.
 
     Args:
@@ -48,7 +49,9 @@ def build_app(url: str | None = None, *, token: str | None = None,
         allowed_hosts: Host allowlist for the DNS-rebind guard (all modes). Defaults to the served
                host + loopback forms. ``["*"]`` only behind a trusted reverse-proxy (warns).
         stateless: Serve in the SDK's stateless mode (no per-session state; each request is
-               self-contained). Useful behind load balancers / for many independent clients.
+               self-contained). Default TRUE — the maintainer's call on FR #25: multi-client
+               behind a proxy is the deployment model this face exists for, and nothing in the
+               governed surface needs a session. Pass False for session-stateful serving.
         json_response: Answer POSTs with plain JSON bodies instead of an SSE stream, for clients
                that prefer it.
 
@@ -150,7 +153,9 @@ def main() -> None:
     allowed = os.environ.get("PROXIMO_MCP_HTTP_ALLOWED_HOSTS", "")
     allowed_hosts = [h.strip() for h in allowed.split(",") if h.strip()] or None
 
-    stateless = os.environ.get("PROXIMO_MCP_HTTP_STATELESS", "").strip().lower() in _TRUEISH
+    # Stateless is the DEFAULT (FR #25 maintainer decision) — opt out with
+    # PROXIMO_MCP_HTTP_STATELESS=0/false/no/off for session-stateful serving.
+    stateless = os.environ.get("PROXIMO_MCP_HTTP_STATELESS", "").strip().lower() not in _FALSISH
     json_response = os.environ.get("PROXIMO_MCP_HTTP_JSON", "").strip().lower() in _TRUEISH
 
     # Bracket bare IPv6 hosts for the URL authority (same fix as the A2A/HTTP entries — an

--- a/src/proximo/mcphttp.py
+++ b/src/proximo/mcphttp.py
@@ -7,22 +7,24 @@ bridge. Those bridges sit OUTSIDE Proximo's perimeter — whatever auth/rebind/C
 then the bridge's, not Proximo's (upstream FR #25). Here every call lands on ``server.mcp`` itself:
 the identical tool registry, trust spine (PLAN-by-default, PROVE, UNDO, the gates), and Proxmox
 token scope a stdio client gets. There is no adapter layer at all — not even ``governed`` — so this
-face cannot diverge from MCP: it IS MCP.
+face cannot diverge from MCP: it IS MCP. (``server.mcp`` is this face's sanctioned seam, beside the
+two every face gets — see ``tests/test_face_contract.py``: the other faces adapt a foreign protocol
+onto the spine through ``governed``; this face serves the spine's native protocol, so the instance
+itself is the only possible mouth.)
 
 The face is an optional extra ([mcp-http], which also pins the SDK floor for the streamable-HTTP
-API); the MCP core keeps zero extra deps. Fail-closed perimeter shared with A2A + HTTP
-(``proximo.webguard``): non-localhost binds refuse without a bearer token, constant-time bearer on
-the ``/mcp`` endpoint (liveness stays open), a Host/DNS-rebind allowlist, and the cross-origin
-(CSRF) guard on POST. The SDK ships its own optional DNS-rebind protection but it defaults OFF
-(backwards compat) — we do not lean on it; the webguard perimeter is authoritative, identical to
-the sibling faces, so the hardening contract cannot drift between transports.
+API); the MCP core keeps zero extra deps. Fail-closed perimeter shared with A2A + HTTP — the ONE
+``webguard.guard_middleware`` stack, in contract order: non-localhost binds refuse without a bearer
+token, constant-time bearer on the ``/mcp`` endpoint (liveness stays open), a Host/DNS-rebind
+allowlist, and the cross-origin (CSRF) guard on POST. The SDK ships its own DNS-rebind protection
+(newer SDKs default it ON with a fixed loopback-only allowlist) — it is explicitly DISABLED here in
+favor of the one authoritative webguard perimeter, so the hardening contract cannot drift between
+transports; see ``build_app``.
 """
 
 from __future__ import annotations
 
 import os
-import sys
-import warnings
 from urllib.parse import urlparse
 
 _DEFAULT_HOST = "127.0.0.1"
@@ -58,17 +60,12 @@ def build_app(url: str | None = None, *, token: str | None = None,
     NOTE: the returned app carries a lifespan (the SDK's session manager) — it must be served by a
     lifespan-running host (uvicorn does; a bare ``httpx.ASGITransport`` does not).
     """
-    from starlette.middleware.trustedhost import TrustedHostMiddleware  # noqa: PLC0415
+    from mcp.server.transport_security import TransportSecuritySettings  # noqa: PLC0415
     from starlette.responses import JSONResponse  # noqa: PLC0415
     from starlette.routing import Route  # noqa: PLC0415
 
     from . import server  # noqa: PLC0415
-    from .webguard import (  # noqa: PLC0415
-        BearerAuthMiddleware,
-        CrossOriginGuardMiddleware,
-        default_allowed_hosts,
-        require_auth_for_public,
-    )
+    from .webguard import guard_middleware, require_auth_for_public  # noqa: PLC0415
 
     if url is None:
         url = f"http://{_DEFAULT_HOST}:{_DEFAULT_PORT}/"
@@ -77,8 +74,6 @@ def build_app(url: str | None = None, *, token: str | None = None,
     require_auth_for_public(urlparse(url).hostname, token, where="advertised URL",
                             face="MCP-HTTP", token_env=_TOKEN_FILE_ENV)
 
-    from mcp.server.transport_security import TransportSecuritySettings  # noqa: PLC0415
-
     server.mcp.settings.streamable_http_path = _MCP_PATH
     server.mcp.settings.stateless_http = stateless
     server.mcp.settings.json_response = json_response
@@ -86,9 +81,9 @@ def build_app(url: str | None = None, *, token: str | None = None,
     # a fixed loopback-only, port-suffixed allowlist — which would 421 every legitimate non-default
     # deployment (public bind with token, reverse-proxy Hosts, the operator's PROXIMO_MCP_HTTP_
     # ALLOWED_HOSTS) and cannot express webguard's list (no bare-host match, no "*"). The shared
-    # webguard stack below covers both of its checks — TrustedHost validates Host (rebind), the
-    # CSRF guard validates Origin + Content-Type — so the SDK layer is disabled rather than fed a
-    # second, driftable copy of the allowlist. (Its POST Content-Type check stays on in either mode.)
+    # guard_middleware stack below covers both of its checks — TrustedHost validates Host (rebind),
+    # the CSRF guard validates Origin + Content-Type — so the SDK layer is disabled rather than fed
+    # a second, driftable copy of the allowlist. (Its POST Content-Type check stays on either way.)
     server.mcp.settings.transport_security = TransportSecuritySettings(
         enable_dns_rebinding_protection=False)
     # Fresh session manager per app: FastMCP caches its manager on first use, and a manager's
@@ -103,26 +98,22 @@ def build_app(url: str | None = None, *, token: str | None = None,
 
     app.router.routes.append(Route("/healthz", _healthz, methods=["GET"]))
 
-    hosts = allowed_hosts or default_allowed_hosts(url)
-    if "*" in hosts:
-        warnings.warn(
-            "PROXIMO MCP-HTTP host allowlist contains '*' — DNS-rebind/Host protection is DISABLED; "
-            "any Host header is accepted. Only safe behind a trusted reverse-proxy that validates "
-            "Host.", stacklevel=2,
-        )
-    _protect_mcp = lambda path: path.rstrip("/") == _MCP_PATH  # noqa: E731
-    # add_middleware PREPENDS, so add inner→outer: the final stack matches the sibling faces —
-    # TrustedHost outermost, then the CSRF guard, bearer innermost. (/healthz stays open, like
-    # the other faces' discovery routes; /mcp itself is the whole protected protocol endpoint.)
-    if token:
-        app.add_middleware(
-            BearerAuthMiddleware, token=token, protect=_protect_mcp,
-            # MCP streamable HTTP is JSON-RPC over HTTP — same 401 body shape as the A2A face.
-            unauthorized_body={"jsonrpc": "2.0", "id": None,
-                               "error": {"code": -32001, "message": "unauthorized"}},
-        )
-    app.add_middleware(CrossOriginGuardMiddleware, protect=_protect_mcp)
-    app.add_middleware(TrustedHostMiddleware, allowed_hosts=hosts)
+    # The shared perimeter stack (TrustedHost → CrossOriginGuard → Bearer-with-token) — one
+    # contract for every face; this face only picks its protected path and 401 body. The SDK
+    # constructs the Starlette app itself, so the stack is mounted afterwards: add_middleware
+    # PREPENDS, so adding in reverse yields exactly guard_middleware's contract order.
+    # (/healthz stays open, like the other faces' discovery routes; /mcp itself is the whole
+    # protected protocol endpoint — POST message, GET SSE stream, DELETE session.)
+    stack = guard_middleware(
+        url, face="MCP-HTTP", token=token,
+        protect=lambda path: path.rstrip("/") == _MCP_PATH,
+        # MCP streamable HTTP is JSON-RPC over HTTP — same 401 body shape as the A2A face.
+        unauthorized_body={"jsonrpc": "2.0", "id": None,
+                           "error": {"code": -32001, "message": "unauthorized"}},
+        allowed_hosts=allowed_hosts,
+    )
+    for cls, args, kwargs in reversed(stack):
+        app.add_middleware(cls, *args, **kwargs)
     return app
 
 
@@ -130,37 +121,25 @@ def main() -> None:
     """``proximo-mcp-http`` entry point — run the MCP-HTTP face with uvicorn (fail-closed)."""
     import uvicorn  # noqa: PLC0415 -- only needed when actually serving
 
-    from . import server  # noqa: PLC0415
-    from .webguard import load_token_file, require_auth_for_public  # noqa: PLC0415
+    from .webguard import (  # noqa: PLC0415
+        apply_surfaces_or_exit,
+        read_face_env,
+        require_auth_for_public,
+        url_authority,
+    )
 
-    # Scope the live tool registry to PROXIMO_SURFACES / configured planes BEFORE serving — the
-    # network faces read the same global registry, so without this the operator's surface config
-    # is silently ignored on this face (it is applied here exactly as the stdio server does it).
-    try:
-        server._apply_surfaces()
-    except ValueError as e:
-        print(f"proximo-mcp-http: {e}", file=sys.stderr)
-        raise SystemExit(1) from None
-
-    host = os.environ.get("PROXIMO_MCP_HTTP_HOST", _DEFAULT_HOST)
-    port = int(os.environ.get("PROXIMO_MCP_HTTP_PORT", str(_DEFAULT_PORT)))
-    token = load_token_file(_TOKEN_FILE_ENV)
+    apply_surfaces_or_exit("proximo-mcp-http")
+    host, port, token, allowed_hosts = read_face_env("MCP_HTTP", default_port=_DEFAULT_PORT)
 
     # FAIL-CLOSED: a public bind with no token never starts.
     require_auth_for_public(host, token, where="bind host", face="MCP-HTTP",
                             token_env=_TOKEN_FILE_ENV)
-
-    allowed = os.environ.get("PROXIMO_MCP_HTTP_ALLOWED_HOSTS", "")
-    allowed_hosts = [h.strip() for h in allowed.split(",") if h.strip()] or None
 
     # Stateless is the DEFAULT (FR #25 maintainer decision) — opt out with
     # PROXIMO_MCP_HTTP_STATELESS=0/false/no/off for session-stateful serving.
     stateless = os.environ.get("PROXIMO_MCP_HTTP_STATELESS", "").strip().lower() not in _FALSISH
     json_response = os.environ.get("PROXIMO_MCP_HTTP_JSON", "").strip().lower() in _TRUEISH
 
-    # Bracket bare IPv6 hosts for the URL authority (same fix as the A2A/HTTP entries — an
-    # unbracketed ::1 parses to hostname=None, which the factory's guard misreads as bind-all).
-    url_host = f"[{host}]" if (":" in host and not host.startswith("[")) else host
-    app = build_app(f"http://{url_host}:{port}/", token=token, allowed_hosts=allowed_hosts,
-                    stateless=stateless, json_response=json_response)
+    app = build_app(f"http://{url_authority(host)}:{port}/", token=token,
+                    allowed_hosts=allowed_hosts, stateless=stateless, json_response=json_response)
     uvicorn.run(app, host=host, port=port)

--- a/src/proximo/mcphttp.py
+++ b/src/proximo/mcphttp.py
@@ -1,0 +1,161 @@
+"""Proximo MCP-over-streamable-HTTP face — the MCP protocol itself, served over the network.
+
+The stdio server IS MCP; this face serves the SAME FastMCP instance over the MCP Streamable HTTP
+transport (the SDK's native ``streamable_http_app()``), for the distributed MCP clients (Claude
+Desktop/Code on another machine, web clients) that would otherwise need a third-party stdio→HTTP
+bridge. Those bridges sit OUTSIDE Proximo's perimeter — whatever auth/rebind/CSRF posture exists is
+then the bridge's, not Proximo's (upstream FR #25). Here every call lands on ``server.mcp`` itself:
+the identical tool registry, trust spine (PLAN-by-default, PROVE, UNDO, the gates), and Proxmox
+token scope a stdio client gets. There is no adapter layer at all — not even ``governed`` — so this
+face cannot diverge from MCP: it IS MCP.
+
+The face is an optional extra ([mcp-http], which also pins the SDK floor for the streamable-HTTP
+API); the MCP core keeps zero extra deps. Fail-closed perimeter shared with A2A + HTTP
+(``proximo.webguard``): non-localhost binds refuse without a bearer token, constant-time bearer on
+the ``/mcp`` endpoint (liveness stays open), a Host/DNS-rebind allowlist, and the cross-origin
+(CSRF) guard on POST. The SDK ships its own optional DNS-rebind protection but it defaults OFF
+(backwards compat) — we do not lean on it; the webguard perimeter is authoritative, identical to
+the sibling faces, so the hardening contract cannot drift between transports.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import warnings
+from urllib.parse import urlparse
+
+_DEFAULT_HOST = "127.0.0.1"
+_DEFAULT_PORT = 41243  # A2A is 41241, HTTP/OpenAPI 41242; the MCP-HTTP face sits beside them
+_TOKEN_FILE_ENV = "PROXIMO_MCP_HTTP_TOKEN_FILE"  # noqa: S105 -- env var NAME, not a secret value
+_MCP_PATH = "/mcp"  # the SDK's default streamable-HTTP path, pinned explicitly (the guards match it)
+
+_TRUEISH = frozenset({"1", "true", "yes", "on"})
+
+
+def build_app(url: str | None = None, *, token: str | None = None,
+              allowed_hosts: list[str] | None = None,
+              stateless: bool = False, json_response: bool = False):
+    """Build the Proximo MCP-over-streamable-HTTP ASGI application.
+
+    Args:
+        url:   Advertised base URL (default ``http://127.0.0.1:41243/``). Its hostname feeds the
+               fail-closed public-bind guard and the default Host allowlist.
+        token: Inbound bearer token. When set, every request to ``/mcp`` (POST message, GET SSE
+               stream, DELETE session) requires it. When None and *url* advertises a non-localhost
+               host, construction is REFUSED (fail-closed). This factory does NOT read the
+               environment — ``main`` loads the token and passes it in.
+        allowed_hosts: Host allowlist for the DNS-rebind guard (all modes). Defaults to the served
+               host + loopback forms. ``["*"]`` only behind a trusted reverse-proxy (warns).
+        stateless: Serve in the SDK's stateless mode (no per-session state; each request is
+               self-contained). Useful behind load balancers / for many independent clients.
+        json_response: Answer POSTs with plain JSON bodies instead of an SSE stream, for clients
+               that prefer it.
+
+    NOTE: the returned app carries a lifespan (the SDK's session manager) — it must be served by a
+    lifespan-running host (uvicorn does; a bare ``httpx.ASGITransport`` does not).
+    """
+    from starlette.middleware.trustedhost import TrustedHostMiddleware  # noqa: PLC0415
+    from starlette.responses import JSONResponse  # noqa: PLC0415
+    from starlette.routing import Route  # noqa: PLC0415
+
+    from . import server  # noqa: PLC0415
+    from .webguard import (  # noqa: PLC0415
+        BearerAuthMiddleware,
+        CrossOriginGuardMiddleware,
+        default_allowed_hosts,
+        require_auth_for_public,
+    )
+
+    if url is None:
+        url = f"http://{_DEFAULT_HOST}:{_DEFAULT_PORT}/"
+
+    # Defense-in-depth: refuse a public advertised URL without a token (covers --factory paths).
+    require_auth_for_public(urlparse(url).hostname, token, where="advertised URL",
+                            face="MCP-HTTP", token_env=_TOKEN_FILE_ENV)
+
+    from mcp.server.transport_security import TransportSecuritySettings  # noqa: PLC0415
+
+    server.mcp.settings.streamable_http_path = _MCP_PATH
+    server.mcp.settings.stateless_http = stateless
+    server.mcp.settings.json_response = json_response
+    # ONE authoritative perimeter, not two: newer SDKs default their own DNS-rebind guard ON with
+    # a fixed loopback-only, port-suffixed allowlist — which would 421 every legitimate non-default
+    # deployment (public bind with token, reverse-proxy Hosts, the operator's PROXIMO_MCP_HTTP_
+    # ALLOWED_HOSTS) and cannot express webguard's list (no bare-host match, no "*"). The shared
+    # webguard stack below covers both of its checks — TrustedHost validates Host (rebind), the
+    # CSRF guard validates Origin + Content-Type — so the SDK layer is disabled rather than fed a
+    # second, driftable copy of the allowlist. (Its POST Content-Type check stays on in either mode.)
+    server.mcp.settings.transport_security = TransportSecuritySettings(
+        enable_dns_rebinding_protection=False)
+    # Fresh session manager per app: FastMCP caches its manager on first use, and a manager's
+    # run() is once-per-instance — a second build (tests, embedders) would otherwise crash at
+    # lifespan start, and the settings above would silently not apply. Private-attr reach, like
+    # governed.list_governed_sync's — the SDK exposes no reset.
+    server.mcp._session_manager = None
+    app = server.mcp.streamable_http_app()
+
+    async def _healthz(_request):
+        return JSONResponse({"ok": True})
+
+    app.router.routes.append(Route("/healthz", _healthz, methods=["GET"]))
+
+    hosts = allowed_hosts or default_allowed_hosts(url)
+    if "*" in hosts:
+        warnings.warn(
+            "PROXIMO MCP-HTTP host allowlist contains '*' — DNS-rebind/Host protection is DISABLED; "
+            "any Host header is accepted. Only safe behind a trusted reverse-proxy that validates "
+            "Host.", stacklevel=2,
+        )
+    _protect_mcp = lambda path: path.rstrip("/") == _MCP_PATH  # noqa: E731
+    # add_middleware PREPENDS, so add inner→outer: the final stack matches the sibling faces —
+    # TrustedHost outermost, then the CSRF guard, bearer innermost. (/healthz stays open, like
+    # the other faces' discovery routes; /mcp itself is the whole protected protocol endpoint.)
+    if token:
+        app.add_middleware(
+            BearerAuthMiddleware, token=token, protect=_protect_mcp,
+            # MCP streamable HTTP is JSON-RPC over HTTP — same 401 body shape as the A2A face.
+            unauthorized_body={"jsonrpc": "2.0", "id": None,
+                               "error": {"code": -32001, "message": "unauthorized"}},
+        )
+    app.add_middleware(CrossOriginGuardMiddleware, protect=_protect_mcp)
+    app.add_middleware(TrustedHostMiddleware, allowed_hosts=hosts)
+    return app
+
+
+def main() -> None:
+    """``proximo-mcp-http`` entry point — run the MCP-HTTP face with uvicorn (fail-closed)."""
+    import uvicorn  # noqa: PLC0415 -- only needed when actually serving
+
+    from . import server  # noqa: PLC0415
+    from .webguard import load_token_file, require_auth_for_public  # noqa: PLC0415
+
+    # Scope the live tool registry to PROXIMO_SURFACES / configured planes BEFORE serving — the
+    # network faces read the same global registry, so without this the operator's surface config
+    # is silently ignored on this face (it is applied here exactly as the stdio server does it).
+    try:
+        server._apply_surfaces()
+    except ValueError as e:
+        print(f"proximo-mcp-http: {e}", file=sys.stderr)
+        raise SystemExit(1) from None
+
+    host = os.environ.get("PROXIMO_MCP_HTTP_HOST", _DEFAULT_HOST)
+    port = int(os.environ.get("PROXIMO_MCP_HTTP_PORT", str(_DEFAULT_PORT)))
+    token = load_token_file(_TOKEN_FILE_ENV)
+
+    # FAIL-CLOSED: a public bind with no token never starts.
+    require_auth_for_public(host, token, where="bind host", face="MCP-HTTP",
+                            token_env=_TOKEN_FILE_ENV)
+
+    allowed = os.environ.get("PROXIMO_MCP_HTTP_ALLOWED_HOSTS", "")
+    allowed_hosts = [h.strip() for h in allowed.split(",") if h.strip()] or None
+
+    stateless = os.environ.get("PROXIMO_MCP_HTTP_STATELESS", "").strip().lower() in _TRUEISH
+    json_response = os.environ.get("PROXIMO_MCP_HTTP_JSON", "").strip().lower() in _TRUEISH
+
+    # Bracket bare IPv6 hosts for the URL authority (same fix as the A2A/HTTP entries — an
+    # unbracketed ::1 parses to hostname=None, which the factory's guard misreads as bind-all).
+    url_host = f"[{host}]" if (":" in host and not host.startswith("[")) else host
+    app = build_app(f"http://{url_host}:{port}/", token=token, allowed_hosts=allowed_hosts,
+                    stateless=stateless, json_response=json_response)
+    uvicorn.run(app, host=host, port=port)

--- a/src/proximo/webguard.py
+++ b/src/proximo/webguard.py
@@ -1,6 +1,6 @@
-"""Shared fail-closed perimeter for Proximo's network faces (A2A, HTTP).
+"""Shared fail-closed perimeter for Proximo's network faces (A2A, HTTP, MCP-over-streamable-HTTP).
 
-Both faces are network CONTROL PLANES over Proxmox, so they share one hardening contract —
+The faces are network CONTROL PLANES over Proxmox, so they share one hardening contract —
 extracted here (starlette-only, no a2a-sdk import) so it cannot drift between transports,
 for the same reason ``governed.call_governed`` is shared:
 
@@ -9,7 +9,8 @@ for the same reason ``governed.call_governed`` is shared:
   - Tokens are loaded run-but-not-read, by file path from an env var; a configured-but-broken
     token file fails LOUD, never silently unauthenticated.
   - Bearer comparison is constant-time; protected paths are chosen per-face (A2A guards its
-    RPC endpoint, HTTP guards /tools/*) while discovery stays readable pre-auth.
+    RPC endpoint, HTTP guards /tools/*, MCP-HTTP guards /mcp) while discovery stays readable
+    pre-auth.
 """
 
 from __future__ import annotations

--- a/tests/test_face_contract.py
+++ b/tests/test_face_contract.py
@@ -3,10 +3,11 @@
 Transport-agnosticism is only real if it's enforced. Every network face must (1) route tool
 calls through ``governed.call_governed``/``list_governed`` — never import a Proxmox backend or
 call the service builders directly, (2) touch ``server`` only for the two sanctioned seams
-(``_apply_surfaces`` registry scoping, ``_ledger`` rejection audits), and (3) mount the ONE
-shared perimeter stack from ``webguard.guard_middleware``, in its contract order. A new face
-(e.g. MCP over streamable HTTP) inherits the spine by following these imports; this test
-refuses the shortcut that would give a transport its own path.
+(``_apply_surfaces`` registry scoping, ``_ledger`` rejection audits) plus any per-face seam
+granted explicitly in EXTRA_SERVER_ATTRS (today: ``server.mcp`` for the MCP-native face, which
+serves the spine's own protocol and so has nothing to adapt), and (3) mount the ONE shared
+perimeter stack from ``webguard.guard_middleware``, in its contract order. This test refuses
+the shortcut that would give a transport its own path.
 """
 from __future__ import annotations
 
@@ -29,6 +30,8 @@ FACE_SOURCES = (
     "a2a/signing.py",
     "a2a/__main__.py",
     "a2a/__init__.py",
+    "mcphttp.py",
+    "_mcp_http_entry.py",
 )
 
 # A face must never reach these — they are the core's internals, behind the governed dispatch.
@@ -46,6 +49,13 @@ FORBIDDEN = (
 # The ONLY server attributes a face may touch (the two sanctioned seams).
 ALLOWED_SERVER_ATTRS = {"_apply_surfaces", "_ledger"}
 
+# Per-face EXTRA seams, granted individually so the global set stays tight. The MCP-HTTP face's
+# whole purpose is serving the FastMCP instance over the SDK's native transport — `server.mcp`
+# IS the spine (governed.call_governed itself delegates to server.mcp.call_tool), so serving it
+# is not a bypass; it is the one face with nothing to adapt. No other face gets this seam: a
+# foreign-protocol face (REST, A2A) touching server.mcp would be skipping governed dispatch.
+EXTRA_SERVER_ATTRS = {"mcphttp.py": {"mcp"}}
+
 
 def _source(rel: str) -> str:
     return (SRC / rel).read_text(encoding="utf-8")
@@ -61,12 +71,14 @@ def test_face_never_touches_core_internals(rel):
 @pytest.mark.parametrize("rel", FACE_SOURCES)
 def test_face_server_seams_are_the_sanctioned_two(rel):
     text = _source(rel)
-    # (?<!a2a\.) — `a2a.server.*` is the A2A SDK's namespace, not proximo's server module.
-    used = set(re.findall(r"(?<!a2a\.)\bserver\.(\w+)", text))
-    stray = used - ALLOWED_SERVER_ATTRS
+    # (?<!a2a\.)/(?<!mcp\.) — `a2a.server.*` / `mcp.server.*` are the SDKs' namespaces, not
+    # proximo's server module.
+    used = set(re.findall(r"(?<!a2a\.)(?<!mcp\.)\bserver\.(\w+)", text))
+    allowed = ALLOWED_SERVER_ATTRS | EXTRA_SERVER_ATTRS.get(rel, set())
+    stray = used - allowed
     assert not stray, (
         f"{rel} uses server.{sorted(stray)} — a face may touch only "
-        f"{sorted(ALLOWED_SERVER_ATTRS)}; everything else goes through the governed dispatch."
+        f"{sorted(allowed)}; everything else goes through the governed dispatch."
     )
 
 
@@ -98,9 +110,10 @@ def _middleware_names(app) -> list[str]:
 
 
 def test_faces_mount_the_same_perimeter_in_contract_order():
-    """Both factories produce the identical guard stack — the faces cannot drift."""
+    """Every factory produces the identical guard stack — the faces cannot drift."""
     a2a_app_mod = pytest.importorskip("proximo.a2a.app")
     from proximo.httpface import build_app as build_http
+    from proximo.mcphttp import build_app as build_mcp_http
 
     with_token = ["TrustedHostMiddleware", "CrossOriginGuardMiddleware", "BearerAuthMiddleware"]
     without = ["TrustedHostMiddleware", "CrossOriginGuardMiddleware"]
@@ -109,3 +122,6 @@ def test_faces_mount_the_same_perimeter_in_contract_order():
     assert _middleware_names(build_http()) == without
     assert _middleware_names(a2a_app_mod.build_app(token="sentinel-token")) == with_token
     assert _middleware_names(a2a_app_mod.build_app()) == without
+    # The MCP-HTTP face mounts the stack onto the SDK-built app — same contract, same order.
+    assert _middleware_names(build_mcp_http(token="sentinel-token")) == with_token
+    assert _middleware_names(build_mcp_http()) == without

--- a/tests/test_mcp_http_entry.py
+++ b/tests/test_mcp_http_entry.py
@@ -1,0 +1,49 @@
+"""The proximo-mcp-http console script ships in the base wheel; without the [mcp-http] extra it
+must print an install hint, not a raw ModuleNotFoundError traceback."""
+import builtins
+
+import pytest
+
+import proximo._mcp_http_entry as entry
+
+
+@pytest.mark.parametrize("missing", ["starlette", "uvicorn"])
+def test_friendly_exit_when_extra_module_missing(monkeypatch, capsys, missing):
+    """Every top-level module the [mcp-http] extra provides gets the hint — uvicorn matters because
+    mcphttp.main() imports it lazily; the shim probes it at import time."""
+    real_import = builtins.__import__
+
+    def missing_module(name, *args, **kwargs):
+        if name == missing or name.startswith(missing + "."):
+            raise ModuleNotFoundError(f"No module named '{missing}'", name=missing)
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", missing_module)
+    with pytest.raises(SystemExit) as ei:
+        entry.main()
+    assert ei.value.code == 2
+    err = capsys.readouterr().err
+    assert 'pip install "proximo-proxmox[mcp-http]"' in err
+    assert f"'{missing}'" in err
+
+
+def test_delegates_to_mcphttp_main_when_installed(monkeypatch):
+    called = []
+    import proximo.mcphttp as mcphttp
+    monkeypatch.setattr(mcphttp, "main", lambda: called.append(True))
+    entry.main()
+    assert called == [True]
+
+
+def test_reraises_when_missing_module_is_not_the_extra(monkeypatch):
+    """A missing SUBmodule (package installed but broken) must traceback, not hide behind the hint."""
+    real_import = builtins.__import__
+
+    def broken_starlette(name, *args, **kwargs):
+        if name == "starlette" or name.startswith("starlette."):
+            raise ModuleNotFoundError("No module named 'starlette._core'", name="starlette._core")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", broken_starlette)
+    with pytest.raises(ModuleNotFoundError):
+        entry.main()

--- a/tests/test_mcphttp_auth.py
+++ b/tests/test_mcphttp_auth.py
@@ -1,0 +1,92 @@
+"""MCP-HTTP face perimeter hardening — fail-closed bind + bearer auth + Host (DNS-rebind) allowlist.
+
+The MCP-over-streamable-HTTP face is a network control plane over Proxmox, exactly like the A2A and
+HTTP faces — and it must obey the same fail-closed rules:
+  - building a PUBLIC-bound app WITHOUT an auth token is REFUSED (not merely warned)
+  - when a token is set: every /mcp request (POST message, GET SSE stream, DELETE session) requires
+    a correct Bearer token; liveness (/healthz) stays open, like the other faces' discovery routes
+  - localhost-default with no token still works for loopback Hosts (dev ergonomics preserved)
+  - the Host guard is installed in ALL modes — non-loopback Hosts are rejected even tokenless
+
+Perimeter rejections happen in middleware, BEFORE the SDK's session manager — so these tests never
+need the app lifespan running: a request that got past the guards would 500 on the unstarted
+manager, never 401/403/400, making any pass here proof the guard fired first.
+"""
+from __future__ import annotations
+
+import pytest
+from starlette.testclient import TestClient
+
+from proximo.mcphttp import build_app
+
+PUBLIC_URL = "http://10.1.2.3:41243/"
+LOCAL = "http://localhost"
+
+
+# --- fail-closed bind -----------------------------------------------------------------------
+
+def test_public_bind_without_token_is_refused():
+    with pytest.raises(ValueError):
+        build_app(PUBLIC_URL)
+
+
+def test_public_bind_with_token_is_allowed():
+    assert build_app(PUBLIC_URL, token="s3cret") is not None
+
+
+def test_bind_all_interfaces_counts_as_public():
+    with pytest.raises(ValueError):
+        build_app("http://0.0.0.0:41243/")
+
+
+def test_localhost_without_token_is_allowed():
+    assert build_app() is not None
+
+
+# --- bearer auth ----------------------------------------------------------------------------
+
+def test_mcp_post_requires_bearer_when_token_set():
+    client = TestClient(build_app(token="s3cret"), base_url=LOCAL)
+    r = client.post("/mcp", json={"jsonrpc": "2.0", "id": 1, "method": "initialize"})
+    assert r.status_code == 401
+    assert r.headers["WWW-Authenticate"] == "Bearer"
+    # JSON-RPC error body, like the A2A face's 401.
+    assert r.json()["error"]["message"] == "unauthorized"
+
+
+def test_mcp_get_sse_stream_requires_bearer_too():
+    # The GET side of streamable HTTP (the server→client SSE stream) is part of the protocol
+    # endpoint — it must not be reachable unauthenticated.
+    client = TestClient(build_app(token="s3cret"), base_url=LOCAL)
+    r = client.get("/mcp", headers={"Accept": "text/event-stream"})
+    assert r.status_code == 401
+
+
+def test_mcp_delete_session_requires_bearer_too():
+    client = TestClient(build_app(token="s3cret"), base_url=LOCAL)
+    assert client.delete("/mcp").status_code == 401
+
+
+def test_wrong_bearer_is_rejected():
+    client = TestClient(build_app(token="s3cret"), base_url=LOCAL)
+    r = client.post("/mcp", json={"jsonrpc": "2.0", "id": 1, "method": "initialize"},
+                    headers={"Authorization": "Bearer wrong"})
+    assert r.status_code == 401
+
+
+def test_health_stays_open_with_token_set():
+    client = TestClient(build_app(token="s3cret"), base_url=LOCAL)
+    assert client.get("/healthz").json() == {"ok": True}
+
+
+# --- Host (DNS-rebind) guard ----------------------------------------------------------------
+
+def test_host_guard_rejects_non_loopback_host_even_tokenless():
+    client = TestClient(build_app(), base_url=LOCAL)
+    r = client.get("/healthz", headers={"Host": "evil.example"})
+    assert r.status_code == 400
+
+
+def test_host_guard_star_warns_loudly():
+    with pytest.warns(UserWarning, match="DNS-rebind"):
+        build_app(allowed_hosts=["*"])

--- a/tests/test_mcphttp_csrf.py
+++ b/tests/test_mcphttp_csrf.py
@@ -1,0 +1,68 @@
+"""MCP-HTTP face — localhost cross-origin (CSRF) defense on the protocol endpoint.
+
+A loopback face with no token (the dev default) is reachable by any web page the operator loads.
+The shared CrossOriginGuardMiddleware refuses cross-origin POSTs to /mcp, exactly as it does for
+/tools/* on the HTTP face and the RPC path on A2A. Rejections fire in middleware, BEFORE the SDK's
+session manager — the app lifespan is never started in these tests, so a request that slipped the
+guard would 500 on the unstarted manager, never the 4xx asserted here. (That legit MCP clients
+pass the guard is proven end-to-end by test_mcphttp_e2e.py, which drives the official client
+through this exact middleware stack.)
+"""
+from __future__ import annotations
+
+from starlette.testclient import TestClient
+
+from proximo.mcphttp import build_app
+
+LOCAL = "http://localhost"
+
+_RPC = {"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+        "params": {"name": "pve_guest_power", "arguments": {"vmid": "102", "action": "stop"}}}
+
+
+def _client() -> TestClient:
+    return TestClient(build_app(), base_url=LOCAL)
+
+
+def test_text_plain_post_is_refused():
+    # The CORS-safelisted Content-Type a forged cross-origin fetch() can carry with no preflight.
+    r = _client().post("/mcp", content=b"{}", headers={"content-type": "text/plain"})
+    assert r.status_code == 415
+
+
+def test_form_urlencoded_post_is_refused():
+    r = _client().post("/mcp", content=b"{}",
+                       headers={"content-type": "application/x-www-form-urlencoded"})
+    assert r.status_code == 415
+
+
+def test_sec_fetch_site_cross_site_is_refused_even_with_json():
+    r = _client().post("/mcp", json=_RPC, headers={"sec-fetch-site": "cross-site"})
+    assert r.status_code == 403
+
+
+def test_sec_fetch_site_same_site_is_refused():
+    r = _client().post("/mcp", json=_RPC, headers={"sec-fetch-site": "same-site"})
+    assert r.status_code == 403
+
+
+def test_cross_origin_header_without_sec_fetch_is_refused():
+    # A browser that omits Fetch-Metadata still sends Origin on a cross-origin POST.
+    r = _client().post("/mcp", headers={"origin": "http://evil.example"})
+    assert r.status_code == 403
+
+
+def test_origin_null_is_refused():
+    # Sandboxed iframe / file:// pages send `Origin: null` — never same-origin, so refuse.
+    r = _client().post("/mcp", headers={"origin": "null"})
+    assert r.status_code == 403
+
+
+def test_oversized_body_is_refused():
+    big = b'{"x":"' + b"a" * 200_000 + b'"}'
+    r = _client().post("/mcp", content=big, headers={"content-type": "application/json"})
+    assert r.status_code == 413
+
+
+def test_health_get_is_never_csrf_checked():
+    assert _client().get("/healthz", headers={"sec-fetch-site": "cross-site"}).status_code == 200

--- a/tests/test_mcphttp_e2e.py
+++ b/tests/test_mcphttp_e2e.py
@@ -53,6 +53,8 @@ async def _drive(app, headers=None):
 
 
 async def test_mcp_client_end_to_end_no_token(tmp_path, monkeypatch):
+    # Defaults — which means STATELESS (`stateless_http=True`, the FR #25 maintainer decision:
+    # multi-client behind a proxy is the deployment model; the governed surface needs no session).
     _configure_env(tmp_path, monkeypatch)
     await _drive(build_app())
 
@@ -64,7 +66,13 @@ async def test_mcp_client_end_to_end_with_bearer(tmp_path, monkeypatch):
     await _drive(build_app(token="s3cret"), headers={"Authorization": "Bearer s3cret"})
 
 
-async def test_stateless_json_mode_end_to_end(tmp_path, monkeypatch):
-    # The load-balancer-friendly posture: stateless sessions + plain-JSON responses.
+async def test_stateful_opt_out_end_to_end(tmp_path, monkeypatch):
+    # The opt-out posture (PROXIMO_MCP_HTTP_STATELESS=0): real per-session state still works.
     _configure_env(tmp_path, monkeypatch)
-    await _drive(build_app(stateless=True, json_response=True))
+    await _drive(build_app(stateless=False))
+
+
+async def test_json_response_mode_end_to_end(tmp_path, monkeypatch):
+    # Plain-JSON responses instead of SSE, for clients that prefer it.
+    _configure_env(tmp_path, monkeypatch)
+    await _drive(build_app(json_response=True))

--- a/tests/test_mcphttp_e2e.py
+++ b/tests/test_mcphttp_e2e.py
@@ -1,0 +1,70 @@
+"""End-to-end: the OFFICIAL MCP streamable-HTTP client drives the Proximo MCP-HTTP app.
+
+The perimeter tests prove hostile requests are refused; this proves the legit path WORKS — the
+whole point of the face (upstream FR #25: no third-party stdio→HTTP bridge). The SDK's real client
+speaks the full Streamable HTTP protocol (initialize handshake, session header, SSE-or-JSON
+responses) through the complete middleware stack (TrustedHost → CSRF guard → bearer) into the SAME
+FastMCP instance the stdio server runs — list_tools returns the full governed surface and a real
+tool (audit_verify) executes through the spine. Uses httpx ASGITransport (in-process, no socket)
+with the app lifespan run explicitly, since the SDK app's session manager lives in the lifespan.
+No live Proxmox (audit_verify reads a temp ledger).
+"""
+from __future__ import annotations
+
+import json
+
+import httpx
+from mcp import ClientSession
+from mcp.client.streamable_http import streamable_http_client
+
+from proximo.mcphttp import build_app
+
+BASE = "http://localhost"
+
+
+def _configure_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("PROXIMO_API_BASE_URL", "https://127.0.0.1:8006/api2/json")
+    monkeypatch.setenv("PROXIMO_NODE", "e2e-node")
+    tok = tmp_path / "e2e.tok"
+    tok.write_text("e2e@pam!t=00000000-0000-0000-0000-000000000000")
+    tok.chmod(0o600)  # the config guard refuses group/other-readable tokens
+    monkeypatch.setenv("PROXIMO_TOKEN_PATH", str(tok))
+    monkeypatch.setenv("PROXIMO_VERIFY_TLS", "true")
+    monkeypatch.setenv("PROXIMO_AUDIT_LOG", str(tmp_path / "e2e-audit.log"))
+
+
+async def _drive(app, headers=None):
+    """Full client session against *app*: initialize → list_tools → call audit_verify."""
+    hx = httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url=BASE,
+                           headers=headers, timeout=30)
+    async with app.router.lifespan_context(app):  # the SDK session manager runs in the lifespan
+        async with streamable_http_client(f"{BASE}/mcp", http_client=hx) as (read, write, _sid):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                tools = await session.list_tools()
+                names = {t.name for t in tools.tools}
+                assert len(names) > 300, "the FULL governed surface, not a curated slice"
+                assert "audit_verify" in names
+                result = await session.call_tool("audit_verify", {})
+                assert result.isError is False
+                # Proximo tools return their JSON as text content — same as over stdio.
+                verdict = json.loads(result.content[0].text)
+                assert verdict["ok"] is True
+
+
+async def test_mcp_client_end_to_end_no_token(tmp_path, monkeypatch):
+    _configure_env(tmp_path, monkeypatch)
+    await _drive(build_app())
+
+
+async def test_mcp_client_end_to_end_with_bearer(tmp_path, monkeypatch):
+    # The same full protocol run with the bearer guard armed: the official client carries the
+    # token on EVERY request (POST message, GET stream, DELETE session), so nothing 401s.
+    _configure_env(tmp_path, monkeypatch)
+    await _drive(build_app(token="s3cret"), headers={"Authorization": "Bearer s3cret"})
+
+
+async def test_stateless_json_mode_end_to_end(tmp_path, monkeypatch):
+    # The load-balancer-friendly posture: stateless sessions + plain-JSON responses.
+    _configure_env(tmp_path, monkeypatch)
+    await _drive(build_app(stateless=True, json_response=True))


### PR DESCRIPTION
## What & why

Closes #25 — a new optional **`proximo-mcp-http`** face (`pip install 'proximo-proxmox[mcp-http]'`) that serves the **same FastMCP instance the stdio server runs** over the MCP SDK's native Streamable HTTP transport (`streamable_http_app()`). Networked MCP clients (Claude Desktop/Code on another machine, web clients) no longer need a third-party stdio→HTTP bridge sitting outside Proximo's perimeter.

There is **no adapter layer at all** — not even `governed` — so this face cannot diverge from MCP: the tool registry, trust spine (PLAN/PROVE/UNDO, the gates), `PROXIMO_SURFACES` scoping, and the Proxmox token scope are inherited by construction.

Perimeter is the shared `proximo.webguard`, identical to the A2A/HTTP faces:
- **Fail-closed public bind** — a non-localhost `PROXIMO_MCP_HTTP_HOST` refuses to start without `PROXIMO_MCP_HTTP_TOKEN_FILE` (hard error, enforced in the entrypoint before uvicorn binds AND inside the app factory, mirroring `_http_entry`).
- **Constant-time bearer** on `/mcp` (POST message, GET SSE stream, DELETE session); `/healthz` stays open.
- **Host/DNS-rebind allowlist** (`PROXIMO_MCP_HTTP_ALLOWED_HOSTS`).
- **Cross-origin (CSRF) guard** + body-size cap on POST — keys on browser-only headers, so native MCP clients pass untouched.

Implemented per your answers to the five design questions in the issue thread:
1. **Auth placement** → webguard, one perimeter shared with a2a/http. The SDK's own DNS-rebinding layer is explicitly disabled — newer SDKs default it ON with a fixed loopback-only, port-suffixed matcher that would 421 every legitimate non-default deployment and cannot express the operator's allowlist; two driftable copies of a perimeter is how holes happen. (Its POST Content-Type check remains active in either mode.)
2. **Naming** → own extra + command: `[mcp-http]` / `proximo-mcp-http`, with the friendly-error shim pattern (`_mcp_http_entry`); no network code in the daemonless default's execution path.
3. **SDK floor** → pinned in the extra, base unchanged: `mcp-http = ["mcp>=1.8.0", "uvicorn>=0.30", "starlette>=1.3.1"]`. Verified floor: `streamable_http_app()` landed in SDK 1.8.0; developed and tested against 1.28.x.
4. **Stateless** → **`stateless_http=True` by default**, as decided. Opt out with `PROXIMO_MCP_HTTP_STATELESS=0` for session-stateful serving; opt-in plain-JSON responses via `PROXIMO_MCP_HTTP_JSON=1`.
5. **Template gotchas** → both handled: the SDK app's session-manager lifespan is served by uvicorn (and run explicitly in the in-process e2e tests; the factory docstring calls out the lifespan requirement), and the public-bind refusal runs in the entrypoint before bind, exactly like `_http_entry`.

Default posture: loopback `127.0.0.1:41243` (beside A2A 41241 / HTTP 41242), no token required on loopback, token mandatory for any non-localhost bind.

## Checks

- [x] `uv run python -m pytest -q` is green — 6682 passed, 3 by-design wrapper-sweep skips
- [x] `uv run ruff check .` is clean
- [x] `uv run pyright` is clean (0 errors)
- [x] New behavior has a test — 4 new suites (27 tests): perimeter/auth (`test_mcphttp_auth.py`), CSRF matrix (`test_mcphttp_csrf.py`), console-shim hints (`test_mcp_http_entry.py`), and an end-to-end run of the **official MCP client** through the full middleware stack (`test_mcphttp_e2e.py`: initialize → `list_tools` full surface → `audit_verify` executing through the spine) in default-stateless, bearer, stateful-opt-out, and plain-JSON modes. Also live-socket smoked via uvicorn (`main()` path: healthz 200, tokenless `/mcp` → 401 JSON-RPC body, authenticated full client session, `_apply_surfaces` auto-scoping applied).
- [x] `CHANGELOG.md` updated under `## [Unreleased]`

## Trust spine

- [x] No mutation path bypasses **PLAN** — the face serves `server.mcp` itself; every call is the identical `call_tool` path a stdio client takes
- [x] No mutation path skips the **PROVE** ledger — same construction
- [x] Safe defaults preserved: loopback bind, API-only, exec still opt-in + loud; `server._apply_surfaces()` runs before serving, exactly like the sibling faces
- [x] No secret, token, internal hostname, or private IP in the diff — the bearer token is loaded run-but-not-read by file path via the shared `load_token_file` (0600-enforced)

## Notes

- The session-manager reset in `build_app` (`server.mcp._session_manager = None`) is a documented private-attr reach, same precedent as `governed.list_governed_sync` — the SDK caches its manager on first use and a manager's `run()` is once-per-instance, so a second build would otherwise crash at lifespan start and settings changes would silently not apply.
- `requirements/` exports are untouched on purpose: the `[mcp-http]` extra introduces no new packages (mcp/starlette/uvicorn are already in the locked set), and `runtime.txt`/`dev.txt` don't export this extra.
- `webguard.py` docstring updated to name the third face; README / SECURITY.md faces sections updated to match.
- Follow-up candidates (not in this diff): documenting the face in `packaging/proximo.env.example` (the A2A/HTTP faces aren't documented there either), and a Dockerfile serving variant.
