### PR TITLE
docs(packaging): document the three network faces in proximo.env.example

### DIFF
--- a/packaging/proximo.env.example
+++ b/packaging/proximo.env.example
@@ -80,3 +80,39 @@ PROXIMO_VERIFY_TLS=true
 # PROXIMO_PDM_CA_BUNDLE=/etc/proximo/pdm-ca.crt
 # Or pin the cert (WIRE-ENFORCED — exact SHA-256 match, strongest for a self-signed PDM):
 # PROXIMO_PDM_FINGERPRINT=AA:BB:CC:...
+
+# --- Network faces (A2A / HTTP / MCP-over-streamable-HTTP) — optional, opt-in per face ---
+# Each face is its own command (proximo-a2a / proximo-http / proximo-mcp-http) and only
+# listens when YOU start it — nothing in this section opens a port by itself. All three
+# share one fail-closed perimeter (proximo.webguard): a non-localhost *_HOST REFUSES to
+# start without its *_TOKEN_FILE (inbound bearer, run-but-not-read; chmod 600 — a separate
+# secret from the Proxmox API tokens above: this one is what YOUR CLIENTS present to
+# Proximo). *_ALLOWED_HOSTS is the Host allowlist for the DNS-rebind guard — set it to the
+# hostname your reverse proxy forwards; an explicit list REPLACES the loopback default, so
+# include localhost/the container name if healthchecks hit those. Setup walkthrough:
+# SETUP.md "Remote / multi-client".
+
+# A2A (Agent2Agent) — proximo-a2a, [a2a] extra
+# PROXIMO_A2A_HOST=127.0.0.1
+# PROXIMO_A2A_PORT=41241
+# PROXIMO_A2A_TOKEN_FILE=/etc/proximo/a2a-bearer.token
+# PROXIMO_A2A_ALLOWED_HOSTS=
+# Sign the agent card (optional; EC P-256 private key, chmod 600):
+# PROXIMO_A2A_SIGNING_KEY_FILE=/etc/proximo/a2a-signing.key
+
+# HTTP/OpenAPI (REST for no-code clients) — proximo-http, [http] extra
+# PROXIMO_HTTP_HOST=127.0.0.1
+# PROXIMO_HTTP_PORT=41242
+# PROXIMO_HTTP_TOKEN_FILE=/etc/proximo/http-bearer.token
+# PROXIMO_HTTP_ALLOWED_HOSTS=
+
+# MCP over Streamable HTTP (networked MCP clients, no bridge) — proximo-mcp-http, [mcp-http] extra
+# PROXIMO_MCP_HTTP_HOST=127.0.0.1
+# PROXIMO_MCP_HTTP_PORT=41243
+# PROXIMO_MCP_HTTP_TOKEN_FILE=/etc/proximo/mcp-bearer.token
+# PROXIMO_MCP_HTTP_ALLOWED_HOSTS=
+# Stateless serving is the DEFAULT (multi-client behind a proxy is the deployment model).
+# Opt out for session-stateful serving:
+# PROXIMO_MCP_HTTP_STATELESS=0
+# Answer POSTs with plain JSON instead of SSE, for clients that prefer it:
+# PROXIMO_MCP_HTTP_JSON=1


### PR DESCRIPTION
## What & why

The follow-up candidate flagged in #28's notes: `packaging/proximo.env.example` documented every backend plane (PVE/PBS/PMG/PDM) but none of the three network faces — an operator wiring `proximo-a2a` / `proximo-http` / `proximo-mcp-http` had to dig the env vars out of SETUP.md or the source.

This adds a commented-out **Network faces** section in the file's existing voice (opt-in planes ship commented), covering per face: `_HOST`, `_PORT`, `_TOKEN_FILE`, `_ALLOWED_HOSTS` — plus `PROXIMO_A2A_SIGNING_KEY_FILE` and the MCP-HTTP `_STATELESS` / `_JSON` knobs.

The section header states the perimeter contract where the operator will actually read it:
- a non-localhost `*_HOST` **refuses to start** without its `*_TOKEN_FILE` (and that bearer is a *separate secret* from the Proxmox API tokens above it in the file — it's what clients present to Proximo, a distinction that trips people up);
- an explicit `*_ALLOWED_HOSTS` **replaces** the loopback default, so healthcheck hosts (localhost / container name) must be listed too — learned live migrating a real deployment off the bridge onto the native face.

## Checks

- [x] `uv run python -m pytest -q` — env-example structural tests + copy-ripple/doc-drift/version gates green (docs-only change)
- [x] `uv run ruff check .` clean (no Python touched)
- [x] `CHANGELOG.md` — no entry: example-config comments only, no behavior change (say the word if you want one)

## Trust spine

- [x] No runtime change of any kind — 36 added lines, all comments
- [x] No secret, token, internal hostname, or private IP in the diff (all `example`/placeholder values)

🤖 Generated with [Claude Code](https://claude.com/claude-code)